### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Done!
 Usage
 ----------------
 
-See the demo XCode project for details
+See the demo Xcode project for details
 
 
 ```Objective-C


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
